### PR TITLE
Convert TitleCase properties to -title-case for vendor prefix support

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ const input = {
     WebkitTransition: '200ms all linear',
     display: ['-webkit-box', '-moz-box']
   }
-}
+};
 
 const styleSheet = stylebuddy.create();
 const styles = styleSheet.add(input);

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ __Generate CSS from JSON without any additional dependencies:__
 ## Contents
 
 - [Basic Example](#basic-example)
+- [Vendor Prefixes](#vendor-prefixes)
 - [API Description](#api)
 - [Configuration](#configuration)
 - [Stylesheet Config](#stylesheet-config)
@@ -53,6 +54,24 @@ document.head.appendChild(styleNode);
 domNode.textContent = css;
 
 console.log(styles.component) // ._component_2513881194
+```
+
+## Vendor Prefixes
+
+```javascript
+import stylebuddy from 'stylebuddy';
+
+const input = {
+  component: {
+    WebkitTransition: '200ms all linear',
+    display: ['-webkit-box', '-moz-box']
+  }
+}
+
+const styleSheet = stylebuddy.create();
+const styles = styleSheet.add(input);
+const css = styleSheet.render();
+// ._component_2513881194{-webkit-transition:200ms all linear;display:-webkit-box;display:-moz-box;}
 ```
 
 ## API

--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@
 __Generate CSS from JSON without any additional dependencies:__
 
 - Supports at-rules like `media queries`
-- Supports pseudo selectors like `:hover`, `:focus`, `:before` etc.
+- Supports pseudo selectors like `:hover`, `:focus`, `:before`, etc.
 - Supports selectors by tag, class and id (e.g.: `body,`, `.components`, `#component`)
+- Supports vendor prefixes like `-webkit-transition`, `display: -moz-box`, etc.
 - Can be used for server side rendering
 - Converts camel case property names to hyphen notation
 - No dependencies
@@ -15,12 +16,12 @@ __Generate CSS from JSON without any additional dependencies:__
 ## Contents
 
 - [Basic Example](#basic-example)
-- [Vendor Prefixes](#vendor-prefixes)
 - [API Description](#api)
 - [Configuration](#configuration)
 - [Stylesheet Config](#stylesheet-config)
 - [Tag Selector](#tag-selector)
 - [Id Selector](#id-selector)
+- [Vendor Prefixes](#vendor-prefixes)
 - [Flexible Stylesheet](#flexible-stylesheet)
 
 ## Basic Example
@@ -54,24 +55,6 @@ document.head.appendChild(styleNode);
 domNode.textContent = css;
 
 console.log(styles.component) // ._component_2513881194
-```
-
-## Vendor Prefixes
-
-```javascript
-import stylebuddy from 'stylebuddy';
-
-const input = {
-  component: {
-    WebkitTransition: '200ms all linear',
-    display: ['-webkit-box', '-moz-box']
-  }
-};
-
-const styleSheet = stylebuddy.create();
-const styles = styleSheet.add(input);
-const css = styleSheet.render();
-// ._component_2513881194{-webkit-transition:200ms all linear;display:-webkit-box;display:-moz-box;}
 ```
 
 ## API
@@ -169,6 +152,24 @@ const css = styleSheet.render(); // #_component{background:#333;}
 const styleNode = document.createElement('style');
 document.head.appendChild(styleNode);
 domNode.textContent = css;
+```
+
+## Vendor Prefixes
+
+```javascript
+import stylebuddy from 'stylebuddy';
+
+const input = {
+  component: {
+    WebkitTransition: '200ms all linear',
+    display: ['-webkit-box', '-moz-box']
+  }
+};
+
+const styleSheet = stylebuddy.create();
+const styles = styleSheet.add(input);
+const css = styleSheet.render();
+// ._component_2513881194{-webkit-transition:200ms all linear;display:-webkit-box;display:-moz-box;}
 ```
 
 ## Flexible Stylesheet

--- a/src/stylebuddy.js
+++ b/src/stylebuddy.js
@@ -18,7 +18,7 @@ const getMergedConfig = (config, defaults) => {
 
 const createProperty = (property, value) => `${property}:${value};`;
 const createRuleSet = (selector, block) => (block !== '' ? `${selector}{${block}}` : '');
-const prefixTitleCase = input => input.replace(/^([A-Z])/g, '-$1');
+const prefixTitleCase = input => input.replace(/^([A-Z])/, '-$1');
 const convertCamelCase = input => input.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase();
 
 const renderProperties = (selector, atRuleNotAllowed) => (

--- a/src/stylebuddy.js
+++ b/src/stylebuddy.js
@@ -18,6 +18,7 @@ const getMergedConfig = (config, defaults) => {
 
 const createProperty = (property, value) => `${property}:${value};`;
 const createRuleSet = (selector, block) => (block !== '' ? `${selector}{${block}}` : '');
+const prefixTitleCase = input => input.replace(/^([A-Z])/g, '-$1');
 const convertCamelCase = input => input.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase();
 
 const renderProperties = (selector, atRuleNotAllowed) => (
@@ -26,7 +27,7 @@ const renderProperties = (selector, atRuleNotAllowed) => (
       throw new Error(AT_RULE_NESTED);
     }
     const values = [].concat(selector[property]);
-    const name = convertCamelCase(property);
+    const name = convertCamelCase(prefixTitleCase(property));
     return values.map((value => createProperty(name, value))).join('');
   })
 );

--- a/src/stylebuddy.test.js
+++ b/src/stylebuddy.test.js
@@ -243,6 +243,22 @@ test('render duplicates properties when the value is an array', () => {
   );
 });
 
+test('render prefixes title case properties with a hyphen', () => {
+  const input = {
+    component: {
+      WebkitTransition: '200ms all linear',
+    },
+  };
+
+  const styleSheet = stylebuddy.create({ appendHash: false });
+  styleSheet.add(input);
+
+  assert.equal(
+    styleSheet.render(),
+    '._component{-webkit-transition:200ms all linear;}'
+  );
+});
+
 test('render supports media queries', () => {
   const input = {
     app: {


### PR DESCRIPTION
renders ``WebkitTransition: '200ms all linear'`` as ``{-webkit-transition:200ms all linear;}``. Together with #12 stylebuddy should support output coming from https://github.com/rofrischmann/inline-style-prefixer