### PR TITLE
Render duplicate properties

### DIFF
--- a/src/stylebuddy.js
+++ b/src/stylebuddy.js
@@ -25,12 +25,9 @@ const renderProperties = (selector, atRuleNotAllowed) => (
     if (atRuleNotAllowed && property[0] === '@') {
       throw new Error(AT_RULE_NESTED);
     }
-    return [].concat(selector[property]).map((propertyValue => (
-      createProperty(
-        convertCamelCase(property),
-        propertyValue
-      )
-    ))).join('');
+    const values = [].concat(selector[property]);
+    const name = convertCamelCase(property);
+    return values.map((value => createProperty(name, value))).join('');
   })
 );
 

--- a/src/stylebuddy.js
+++ b/src/stylebuddy.js
@@ -25,10 +25,12 @@ const renderProperties = (selector, atRuleNotAllowed) => (
     if (atRuleNotAllowed && property[0] === '@') {
       throw new Error(AT_RULE_NESTED);
     }
-    return createProperty(
-      convertCamelCase(property),
-      selector[property]
-    );
+    return [].concat(selector[property]).map((propertyValue => (
+      createProperty(
+        convertCamelCase(property),
+        propertyValue
+      )
+    ))).join('');
   })
 );
 

--- a/src/stylebuddy.test.js
+++ b/src/stylebuddy.test.js
@@ -227,6 +227,22 @@ test('render converts camel case properties into dash hyphen', () => {
   );
 });
 
+test('render duplicates properties when the value is an array', () => {
+  const input = {
+    component: {
+      display: ['-webkit-box', '-moz-box'],
+    },
+  };
+
+  const styleSheet = stylebuddy.create({ appendHash: false });
+  styleSheet.add(input);
+
+  assert.equal(
+    styleSheet.render(),
+    '._component{display:-webkit-box;display:-moz-box;}'
+  );
+});
+
 test('render supports media queries', () => {
   const input = {
     app: {


### PR DESCRIPTION
renders ``display: ['-webkit-box', '-moz-box']`` as ``{display:-webkit-box;display:-moz-box;}``. Together with #11 stylebuddy should support output coming from https://github.com/rofrischmann/inline-style-prefixer