### PR TITLE
Fix rendering of pseudo selectors with more than one attribute

### DIFF
--- a/src/stylebuddy.js
+++ b/src/stylebuddy.js
@@ -35,7 +35,7 @@ const renderProperties = (selector, atRuleNotAllowed) => (
 const renderPseudoSelectors = (pseudoSelectors, element) => (
   Object.keys(pseudoSelectors).map(selector => createRuleSet(
     element + selector,
-    renderProperties(pseudoSelectors[selector], true)
+    renderProperties(pseudoSelectors[selector], true).join('')
   ))
 );
 

--- a/src/stylebuddy.test.js
+++ b/src/stylebuddy.test.js
@@ -198,6 +198,7 @@ test('render supports pseudo selectors', () => {
       background: 'yellow',
       ':hover': {
         background: 'blue',
+        color: 'black',
       },
     },
   };
@@ -207,7 +208,7 @@ test('render supports pseudo selectors', () => {
 
   assert.equal(
     styleSheet.render(),
-    '._component{background:yellow;}._component:hover{background:blue;}'
+    '._component{background:yellow;}._component:hover{background:blue;color:black;}'
   );
 });
 


### PR DESCRIPTION
Using pseudo selectors we found an issue. Whenever we have more than one style attribute inside the pseudo selector its not rendered properly.

e.g. 

~~~
foo: {
  ':hover': {
    color: '#ffffff',
    display: 'block',
    height: 0
  }
}
~~~

leads to:

~~~
.foo:hover {
    color: #ffffff;
    , display: block;
    , height: 0;
}
~~~

fixes #21 